### PR TITLE
Two test cleanups

### DIFF
--- a/onmetal_ironic_hardware_manager/tests/data/ddoemcli_format_out.txt
+++ b/onmetal_ironic_hardware_manager/tests/data/ddoemcli_format_out.txt
@@ -1,0 +1,19 @@
+
+****************************************************************************
+   Seagate WarpDrive Management Utility
+   Version 112.00.07.00 (2014.08.27)
+   Copyright (c) 2014 Seagate Technologies LLC. All Rights Reserved.
+****************************************************************************
+Seagate WarpDrive Management Utility: Preparing WarpDrive for format.
+Seagate WarpDrive Management Utility: Please wait. Format of WarpDrive is in progress.....
+Media Erase is set to extended
+Media Erase is changed to standard.
+Media Erase is set to extended
+Media Erase is changed to standard.
+Media Erase is set to extended
+Media Erase is changed to standard.
+Media Erase is set to extended
+Media Erase is changed to standard.
+Seagate WarpDrive Management Utility: WarpDrive format successfully completed.
+
+Seagate WarpDrive Management Utility: Execution completed successfully.

--- a/onmetal_ironic_hardware_manager/tests/data/ddoemcli_listall_out.txt
+++ b/onmetal_ironic_hardware_manager/tests/data/ddoemcli_listall_out.txt
@@ -1,0 +1,13 @@
+
+****************************************************************************
+   SEAGATE WarpDrive Management Utility
+   Version 112.00.07.00 (2014.08.27)
+   Copyright (c) 2014 Seagate Technologies LLC. All Rights Reserved.
+****************************************************************************
+
+ID    WarpDrive     Package Version    PCI Address
+--    ---------     ---------------    -----------
+1     NWD-BLP4-1600      12.22.00.00        00:02:00:00
+2     NWD-BLP4-1600      12.22.00.00        00:04:00:00
+
+Seagate WarpDrive Management Utility: Execution completed successfully.

--- a/onmetal_ironic_hardware_manager/tests/manager.py
+++ b/onmetal_ironic_hardware_manager/tests/manager.py
@@ -28,49 +28,14 @@ if six.PY2:
 else:
     OPEN_FUNCTION_NAME = 'builtins.open'
 
-DDOEMCLI_LISTALL_OUT = (
-    '\n'
-    '*************************************************************************'
-        '***\n'
-    '   SEAGATE WarpDrive Management Utility\n'
-    '   Version 112.00.07.00 (2014.08.27)\n'
-    '   Copyright (c) 2014 Seagate Technologies LLC. All Rights Reserved.\n'
-    '*************************************************************************'
-        '***\n'
-    '\n'
-    'ID    WarpDrive     Package Version    PCI Address\n'
-    '--    ---------     ---------------    -----------\n'
-    '1     NWD-BLP4-1600      12.22.00.00        00:02:00:00\n'
-    '2     NWD-BLP4-1600      12.22.00.00        00:04:00:00\n'
-    '\n'
-    'Seagate WarpDrive Management Utility: Execution completed successfully.\n'
-)
 
-DDOEMCLI_FORMAT_OUT = (
-    '\n'
-    '*************************************************************************'
-        '***\n'
-    '   Seagate WarpDrive Management Utility\n'
-    '   Version 112.00.07.00 (2014.08.27)\n'
-    '   Copyright (c) 2014 Seagate Technologies LLC. All Rights Reserved.\n'
-    '*************************************************************************'
-        '***\n'
-    'Seagate WarpDrive Management Utility: Preparing WarpDrive for format.\n'
-    'Seagate WarpDrive Management Utility: Please wait. Format of WarpDrive '
-        'is in progress.....\n'
-    'Media Erase is set to extended\n'
-    'Media Erase is changed to standard.\n'
-    'Media Erase is set to extended\n'
-    'Media Erase is changed to standard.\n'
-    'Media Erase is set to extended\n'
-    'Media Erase is changed to standard.\n'
-    'Media Erase is set to extended\n'
-    'Media Erase is changed to standard.\n'
-    'Seagate WarpDrive Management Utility: WarpDrive format successfully '
-        'completed.\n'
-    '\n'
-    'Seagate WarpDrive Management Utility: Execution completed successfully.\n'
-)
+def _read_file(test_data):
+    filename = os.path.join(os.path.dirname(__file__), test_data)
+    with open(filename, 'r') as data:
+        return data.read()
+
+DDOEMCLI_FORMAT_OUT = _read_file('data/ddoemcli_format_out.txt')
+DDOEMCLI_LISTALL_OUT = _read_file('data/ddoemcli_listall_out.txt')
 
 
 class TestOnMetalHardwareManager(test_base.BaseTestCase):

--- a/onmetal_ironic_hardware_manager/tests/manager.py
+++ b/onmetal_ironic_hardware_manager/tests/manager.py
@@ -69,8 +69,7 @@ class TestOnMetalHardwareManager(test_base.BaseTestCase):
     @mock.patch.object(utils, 'execute')
     def test__list_lsi_devices(self, mocked_execute):
         mocked_execute.side_effect = [
-            (DDOEMCLI_LISTALL_OUT, ''),
-            (DDOEMCLI_FORMAT_OUT, ''),
+            (DDOEMCLI_LISTALL_OUT, '')
         ]
         devices = self.hardware._list_lsi_devices()
         self.assertEqual(self.FAKE_DEVICES, devices)


### PR DESCRIPTION
(two commits)
1) Move test data into text files that are loaded
2) Get rid of unneeded DDOEMCLI_FORMAT_OUT output being added in the list devices test.