### PR TITLE
Adds support for IPA clean steps, changes error types to support new …

### DIFF
--- a/onmetal_ironic_hardware_manager/__init__.py
+++ b/onmetal_ironic_hardware_manager/__init__.py
@@ -79,62 +79,62 @@ class OnMetalHardwareManager(hardware.GenericHardwareManager):
             {
                 'step': 'remove_bootloader',
                 'interface': 'deploy',
-                'priority': 10,
+                'priority': 100,
                 'reboot_requested': False,
             },
             {
                 'step': 'upgrade_bios',
                 'interface': 'deploy',
-                'priority': 9,
+                'priority': 90,
                 'reboot_requested': True,
             },
             {
                 'step': 'decom_bios_settings',
                 'interface': 'deploy',
-                'priority': 8,
+                'priority': 80,
                 'reboot_requested': True,
             },
             {
                 'step': 'update_warpdrive_firmware',
                 'interface': 'deploy',
-                'priority': 7,
+                'priority': 70,
                 'reboot_requested': False,
             },
             # This step is a no-op for now.
             {
                 'step': 'update_intel_nic_firmware',
                 'interface': 'deploy',
-                'priority': 6,
+                'priority': 60,
                 'reboot_requested': True,
             },
             {
                 'step': 'erase_devices',
                 'interface': 'deploy',
-                'priority': 5,
+                'priority': 50,
                 'reboot_requested': False,
             },
             {
                 'step': 'get_disk_metrics',
                 'interface': 'deploy',
-                'priority': 4,
+                'priority': 40,
                 'reboot_requested': False
             },
             {
                 'step': 'customer_bios_settings',
                 'interface': 'deploy',
-                'priority': 3,
+                'priority': 30,
                 'reboot_requested': True,
             },
             {
                 'step': 'verify_ports',
                 'interface': 'deploy',
-                'priority': 2,
+                'priority': 20,
                 'reboot_requested': False
             },
             {
                 'step': 'verify_hardware',
                 'interface': 'deploy',
-                'priority': 1,
+                'priority': 10,
                 'reboot_requested': False
             }
         ]

--- a/onmetal_ironic_hardware_manager/tests/manager.py
+++ b/onmetal_ironic_hardware_manager/tests/manager.py
@@ -381,7 +381,10 @@ class TestOnMetalHardwareManager(test_base.BaseTestCase):
         mocked_realpath.return_value = ('/sys/devices/pci0000:00/0000:00:02.0'
             '/0000:06:00.0/host3/target3:1:0/3:1:0:0/block/sdb')
 
-        self.assertRaises(errors.BlockDeviceEraseError,
+        # A CleaningError is raised instead of a BlockDeviceEraseError because
+        # the error was with the cleaning finding the block device rather than
+        # actually erasing an existing block device.
+        self.assertRaises(errors.CleaningError,
                           self.hardware.erase_block_device,
                           self.block_device)
 
@@ -400,7 +403,10 @@ class TestOnMetalHardwareManager(test_base.BaseTestCase):
         mocked_realpath.return_value = ('/sys/devices/pci0000:00/0000:00:02.0'
             '/0000:02:00.0/host3/target3:1:0/3:1:0:0/block/sdb')
 
-        self.assertRaises(errors.BlockDeviceEraseError,
+        # A CleaningError is raised instead of a BlockDeviceEraseError because
+        # the error was with the cleaning finding the block device rather than
+        # actually erasing an existing block device.
+        self.assertRaises(errors.CleaningError,
                           self.hardware.erase_block_device,
                           self.block_device)
 
@@ -679,7 +685,7 @@ class TestOnMetalHardwareManager(test_base.BaseTestCase):
             hardware.BlockDevice('/dev/sdb', '32G MLC SATADOM', 33554432,
                                  False)]
 
-        self.assertRaises(errors.VerificationError,
+        self.assertRaises(errors.CleaningError,
                           self.hardware.verify_hardware, {}, [])
 
     def test_verify_blockdevice_count_io_missing_satadom(self):
@@ -692,7 +698,7 @@ class TestOnMetalHardwareManager(test_base.BaseTestCase):
             hardware.BlockDevice('/dev/sdb', 'NWD-BLP4-1600', 1073741824,
                                  False)]
 
-        self.assertRaises(errors.VerificationError,
+        self.assertRaises(errors.CleaningError,
                           self.hardware.verify_hardware, {}, [])
 
     def test_verify_blockdevice_count_missing_satadom(self):
@@ -701,7 +707,7 @@ class TestOnMetalHardwareManager(test_base.BaseTestCase):
         self.hardware.list_block_devices = mock.Mock()
         self.hardware.list_block_devices.return_value = []
 
-        self.assertRaises(errors.VerificationError,
+        self.assertRaises(errors.CleaningError,
                           self.hardware.verify_hardware, {}, [])
 
     def test_verify_blockdevice_count_pass(self):
@@ -832,7 +838,7 @@ class TestOnMetalVerifyPorts(test_base.BaseTestCase):
             ('switch2', 'Eth2/1')
         ]
 
-        self.assertRaises(errors.VerificationFailed,
+        self.assertRaises(errors.CleaningError,
                           self.hardware.verify_ports,
                           self.node,
                           self.ports)
@@ -857,14 +863,14 @@ class TestOnMetalVerifyPorts(test_base.BaseTestCase):
             ('switch1', 'Eth1/1'),
         ]
 
-        self.assertRaises(errors.VerificationFailed,
+        self.assertRaises(errors.CleaningError,
                           self.hardware.verify_ports,
                           self.node,
                           self.ports)
 
     def test__get_tlv_malformed(self):
         self.lldp_info['eth0'][0] = ('bad tlv',)
-        self.assertRaises(errors.VerificationError,
+        self.assertRaises(errors.CleaningError,
                           self.hardware._get_tlv,
                           1,
                           self.lldp_info['eth0'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/rackerlabs/ironic-python-agent.git@teeth-latest#egg=ironic_python_agent
+-e git+https://github.com/rackerlabs/ironic-python-agent.git@upstream#egg=ironic_python_agent

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/rackerlabs/ironic-python-agent.git@upstream#egg=ironic_python_agent
+-e git+https://github.com/rackerlabs/ironic-python-agent.git@teeth-latest#egg=ironic_python_agent

--- a/tox.ini
+++ b/tox.ini
@@ -12,9 +12,6 @@ deps = -r{toxinidir}/requirements.txt
 commands =
   python setup.py testr --slowest --testr-args='{posargs:}'
 
-[tox:jenkins]
-downloadcache = ~/cache/pip
-
 [testenv:pep8]
 commands =
   flake8 {posargs:onmetal_ironic_hardware_manager}


### PR DESCRIPTION
…IPA error types, removes a non-existent decommissioning step.

I noticed that the verify_properties step appears to never have been supported, so I removed it.

Additionally, I changed all the VerificationErrors to CleaningErrors. I couldn't find where VerificationErrors were supported, upstream or downstream.

This still needs to be tested. This must be used with a version of IPA that uses clean steps.

Note: Forgot to run through tox, definitely wait for those to finish before merging.