### PR TITLE
Fixes get_disk_metrics to have 3 arguments and removes erase_devices

### DIFF
--- a/onmetal_ironic_hardware_manager/__init__.py
+++ b/onmetal_ironic_hardware_manager/__init__.py
@@ -75,6 +75,9 @@ class OnMetalHardwareManager(hardware.GenericHardwareManager):
         :return: a default list of decommission steps, as a list of
         dictionaries
         """
+        # NOTE(supermari0): GenericHardwareManager is assumed to have an
+        # erase_devices step. We implement erase_block_device which is called
+        # by erase_devices. We need to be aware of that if IPA changes.
         return [
             {
                 'step': 'remove_bootloader',
@@ -355,7 +358,7 @@ class OnMetalHardwareManager(hardware.GenericHardwareManager):
         for name, gauge in six.iteritems(metrics_to_send):
             logger.gauge(name, gauge)
 
-    def get_disk_metrics(self):
+    def get_disk_metrics(self, node, ports):
         smart_data_columns = ['VALUE', 'WORST', 'RAW_VALUE']
         block_devices = self.list_block_devices()
         for block_device in block_devices:

--- a/onmetal_ironic_hardware_manager/tests/manager.py
+++ b/onmetal_ironic_hardware_manager/tests/manager.py
@@ -570,7 +570,11 @@ class TestOnMetalHardwareManager(test_base.BaseTestCase):
         self.hardware._get_smartctl_attributes.return_value = (
                 SMARTCTL_ATTRIBUTES)
 
-        self.hardware.get_disk_metrics()
+        # get_disk_metrics is forced to take 2 additional arguments for node
+        # and ports by IPA
+        node = mock.Mock()
+        ports = mock.Mock()
+        self.hardware.get_disk_metrics(node, ports)
 
         self.hardware._send_gauges.assert_has_calls([
             mock.call('smartdata_sdb_32GMLCSATADOM', {


### PR DESCRIPTION
IPA now requires 3 arguments to each method called in the clean steps.
Additionally, we're subclassing GenericHardwareManager, which already has an
erase_devices step, so erase_devices has been removed from this hardware
manager.